### PR TITLE
修复图片裁剪问题

### DIFF
--- a/ninegridview/src/main/java/com/lzy/ninegrid/NineGridView.java
+++ b/ninegridview/src/main/java/com/lzy/ninegrid/NineGridView.java
@@ -95,9 +95,7 @@ public class NineGridView extends ViewGroup {
         int childrenCount = mImageInfo.size();
         for (int i = 0; i < childrenCount; i++) {
             ImageView childrenView = (ImageView) getChildAt(i);
-            if (mImageLoader != null) {
-                mImageLoader.onDisplayImage(getContext(), childrenView, mImageInfo.get(i).thumbnailUrl);
-            }
+            
             int rowNum = i / columnCount;
             int columnNum = i % columnCount;
             int left = (gridWidth + gridSpacing) * columnNum + getPaddingLeft();
@@ -105,6 +103,10 @@ public class NineGridView extends ViewGroup {
             int right = left + gridWidth;
             int bottom = top + gridHeight;
             childrenView.layout(left, top, right, bottom);
+            
+            if (mImageLoader != null) {
+                mImageLoader.onDisplayImage(getContext(), childrenView, mImageInfo.get(i).thumbnailUrl);
+            }
         }
     }
 


### PR DESCRIPTION
diaplayImage异步任务  可能会和childrenView.layout导致并发问题，  导致Glide等框架计算图片大小 与 childrenView.layout后不匹配。导致图片显示放大